### PR TITLE
Add WooCommerce Blocks & HPOS compatibility and fix Store API checkout fatal error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,89 +4,86 @@ Contributors: Hydrogenpay
 
 Requires at least: 3.0.0
 
-Tested up to: 8.2.5
+Tested up to: 10.9.4 (WooCommerce) / 7.0.1 (WordPress)
 
-Stable tag: 1.0.0
+Stable tag: 1.1.0
 
 License: GPLv2 or later
 
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-# Introduction 
+# Introduction
 
 This document outlines the scope of work for integrating the Hydrogen Payment Gateway WooCommerce into a merchant’s website. Hydrogen Payment Gateway enables fast, secure payments through card transactions and account transfers, optimizing the delivery of goods and services.
 
 # Getting Started
 
-1.	Installation process
+1. Installation process
+   1. Download the plugin zip file using the link https://github.com/HydrogenAfrica/woocommerce-hydrogen-payment-gateway-plugin/archive/refs/heads/main.zip
+   2. Login to your WordPress Admin. Click on "Plugins > Add New" from the left hand menu.
+   3. Click on the "Upload" option, then click "Choose File" to select the zip file from your computer. Once selected, press "OK" and press the "Install Now" button.
+   4. Activate the plugin.
+   5. Open the settings page for WooCommerce and click the "Payment" tab.
+   6. Configure your Hydrogen Payment Gateway settings. See below for details.
 
-    1.  Download the plugin zip file using the link https://github.com/HydrogenAfrica/woocommerce-hydrogen-payment-gateway-plugin/archive/refs/heads/main.zip
-    2.  Login to your WordPress Admin. Click on "Plugins > Add New" from the left hand menu.
-    3.  Click on the "Upload" option, then click "Choose File" to select the zip file from your computer. Once selected, press "OK" and press the "Install Now" button.
-    4.  Activate the plugin.
-    5.  Open the settings page for WooCommerce and click the "Payment" tab.
-    6.  Configure your Hydrogen Payment Gateway settings. See below for details.
+      Configure the plugin:
 
-        Configure the plugin:
+      To configure the plugin, go to WooCommerce > Settings from the left hand menu, then click Checkout from the top tab. You will see Hydrogen Payment Gateway as part of the available Checkout Options. Click on it to Manage to configure the Hudrogen payment gateway.
+      - Enable/Disable - check the box to enable Hydrogen Payment Gateway.
+      - Title - allows you to determine what your customers will see this payment option as on the checkout page.
+      - Description - controls the message that appears under the payment fields on the checkout page. Here you can list the types of cards you accept.
+      - Test Mode - Check to enable test mode. Test mode enables you to test payments before going live. If you ready to start receving real payment on your site, kindly uncheck this.
+      - Sandbox - Enter your sandbox API Keys here. Get your API Keys from your Hydrogen account under Settings > [Developer/API](<[url](https://dashboard.hydrogenpay.com/merchant/profile/api-integration)>)
+      - Live API Keys - Enter your Live API Keys here. Get your API Keys from your Hydrogen account under Settings > [Developer/API](<[url](https://dashboard.hydrogenpay.com/merchant/profile/api-integration)>)
+      - Payment Option - Popup shows the Hydrogen payment popup on the page while Redirect will redirect the customer to Hydrogen Payment Site to make payment.
+      - Click on Save Changes for the changes you made to be effected.
 
-        To configure the plugin, go to WooCommerce > Settings from the left hand menu, then click Checkout from the top tab. You will see Hydrogen Payment Gateway as part of the available Checkout Options. Click on it to Manage to configure the Hudrogen payment gateway.
+2. Software dependencies
+   1. You need to have WooCommerce plugin installed and activated on your WordPress site.
+   2. You need to open a Hydrogen account
+   3. works with WooCommerce v2.6 and above
 
-        * Enable/Disable - check the box to enable Hydrogen Payment Gateway.
-        * Title - allows you to determine what your customers will see this payment option as on the checkout page.
-        * Description - controls the message that appears under the payment fields on the checkout page. Here you can list the types of cards you accept.
-        * Test Mode - Check to enable test mode. Test mode enables you to test payments before going live. If you ready to start receving real payment on your site, kindly uncheck this.
-        * Sandbox - Enter your sandbox API Keys here. Get your API Keys from your Hydrogen account under Settings > [Developer/API]([url](https://dashboard.hydrogenpay.com/merchant/profile/api-integration))
-        * Live API Keys - Enter your Live API Keys here. Get your API Keys from your Hydrogen account under Settings > [Developer/API]([url](https://dashboard.hydrogenpay.com/merchant/profile/api-integration))
-        * Payment Option - Popup shows the Hydrogen payment popup on the page while Redirect will redirect the customer to Hydrogen Payment Site to make payment.
-        * Click on Save Changes for the changes you made to be effected.
+3. Latest releases
+   1. 1.1.0 - July 2026.
+   2. 1.0.0 - September 26, 2024.
 
-2.	Software dependencies
+4. API references
+   - https://dashboard.hydrogenpay.com/
 
-    1. You need to have WooCommerce plugin installed and activated on your WordPress site.
-    2. You need to open a Hydrogen account
-    3. works with WooCommerce v2.6 and above
-
-3.	Latest releases
-
-    1. 1.0.0 - September 26, 2024.
-
-
-4.	API references
-
-    * https://dashboard.hydrogenpay.com/
-
-    * https://docs.hydrogenpay.com/docs/authentication
+   - https://docs.hydrogenpay.com/docs/authentication
 
 # Build and Test
-Describe and show how to build your code and run the tests. 
+
+Describe and show how to build your code and run the tests.
 
 # Contribute
-Explain how other users and developers can contribute to make your code better. 
+
+Explain how other users and developers can contribute to make your code better.
 
 If you discover a bug or have a solution to improve the Hydrogen Payment Gateway for the WooCommerce plugin,
 we welcome your contributions to enhance the code.
 
- * Visit our GitHub repository: [https://dev.azure.com/HydrogenPay/Payment%20Gateway/_git/be_pg_wc_plugin]
+- Visit our GitHub repository: [https://dev.azure.com/HydrogenPay/Payment%20Gateway/_git/be_pg_wc_plugin]
 
- * Create a detailed bug report or feature request in the "Issues" section.
+- Create a detailed bug report or feature request in the "Issues" section.
 
- * If you have a code improvement or bug fix, feel free to submit a pull request.
+- If you have a code improvement or bug fix, feel free to submit a pull request.
 
-        * Fork the repository on GitHub
+       * Fork the repository on GitHub
 
-        * Clone the repository into your local system and create a branch that describes what you are working on by pre-fixing with feature-name.
+       * Clone the repository into your local system and create a branch that describes what you are working on by pre-fixing with feature-name.
 
-        * Make the changes to your forked repository's branch. Ensure you are using PHP Coding Standards (PHPCS).
+       * Make the changes to your forked repository's branch. Ensure you are using PHP Coding Standards (PHPCS).
 
-        * Make commits that are descriptive and breaks down the process for better understanding.
+       * Make commits that are descriptive and breaks down the process for better understanding.
 
-        * Push your fix to the remote version of your branch and create a PR that aims to merge that branch into master.
-        
-        * After you follow the step above, the next stage will be waiting on us to merge your Pull Request.
+       * Push your fix to the remote version of your branch and create a PR that aims to merge that branch into master.
 
- Your contributions help us make the PG plugin even better for the community. Thank you!
+       * After you follow the step above, the next stage will be waiting on us to merge your Pull Request.
 
- # Screenshots
+Your contributions help us make the PG plugin even better for the community. Thank you!
+
+# Screenshots
 
 ### 1. Hydrogen WooCommerce Setting Page
 

--- a/assets/js/hydrogen.js
+++ b/assets/js/hydrogen.js
@@ -195,11 +195,10 @@ jQuery(function ($) {
         // Remove any existing spinners
         $("#loading-spinner").remove();
 
-        // Redirect to cart page when user cancels payment (no loader needed)
-        let cartUrl =
-          wc_hydrogen_params.hydrogen_wc_redirect_url ||
-          window.location.origin + "/cart/";
-        window.location.href = cartUrl;
+        // Redirect back to checkout pay page so customer can try again
+        let cancelUrl =
+          wc_hydrogen_params.hydrogen_wc_checkout_url || window.location.href;
+        window.location.href = cancelUrl;
 
         // Return false to prevent any further processing
         return false;

--- a/assets/js/hydrogen.min.js
+++ b/assets/js/hydrogen.min.js
@@ -137,8 +137,7 @@ jQuery(function (e) {
         const n = document.getElementById("hydrogenPay_myModal");
         (n && n.remove(), e("#loading-spinner").remove());
         let t =
-          wc_hydrogen_params.hydrogen_wc_redirect_url ||
-          window.location.origin + "/cart/";
+          wc_hydrogen_params.hydrogen_wc_checkout_url || window.location.href;
         return ((window.location.href = t), !1);
       });
     e("form#payment-form, form#order_review")

--- a/includes/class-wc-gateway-custom-hydrogen.php
+++ b/includes/class-wc-gateway-custom-hydrogen.php
@@ -418,11 +418,11 @@ class WC_Gateway_Custom_Hydrogen extends WC_Gateway_Hydrogen_Subscriptions
 			return;
 		}
 
-		// Verify the nonce before processing further
-		if (!isset($_GET['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['nonce'])), 'wc_hydrogen_payment_nonce')) {
+		// Verify the nonce if present (nonce is added to URL after process_payment for inline/popup flow)
+		if (isset($_GET['nonce']) && !wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['nonce'])), 'wc_hydrogen_payment_nonce')) {
 			wp_die(
-				esc_html__('Invalid request. Nonce verification failed.', 'text-domain'),
-				esc_html__('Error', 'text-domain'),
+				esc_html__('Invalid request. Nonce verification failed.', 'woo-hydrogen'),
+				esc_html__('Error', 'woo-hydrogen'),
 				array('response' => 403)
 			);
 		}

--- a/includes/class-wc-gateway-hydrogen.php
+++ b/includes/class-wc-gateway-hydrogen.php
@@ -615,11 +615,11 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 			return;
 		}
 
-		// Verify the nonce before processing further
-		if (!isset($_GET['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['nonce'])), 'wc_hydrogen_payment_nonce')) {
+		// Verify the nonce if present (nonce is added to URL after process_payment for inline/popup flow)
+		if (isset($_GET['nonce']) && !wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['nonce'])), 'wc_hydrogen_payment_nonce')) {
 			wp_die(
-				esc_html__('Invalid request. Nonce verification failed.', 'text-domain'),
-				esc_html__('Error', 'text-domain'),
+				esc_html__('Invalid request. Nonce verification failed.', 'woo-hydrogen'),
+				esc_html__('Error', 'woo-hydrogen'),
 				array('response' => 403)
 			);
 		}
@@ -814,13 +814,15 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 	public function process_payment($order_id)
 	{
 
-		// Verify nonce before processing
+		// Verify nonce before processing (only for classic checkout; blocks checkout does not send this nonce)
 		if (
-			!isset($_POST['wc_hydrogen_payment_nonce']) ||
+			isset($_POST['wc_hydrogen_payment_nonce']) &&
 			!wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['wc_hydrogen_payment_nonce'])), 'wc_hydrogen_payment_nonce_action')
 		) {
 			wc_add_notice(__('Security check failed, please try again.', 'woocommerce'), 'error');
-			return;
+			return array(
+				'result' => 'failure',
+			);
 		}
 
 		if ('redirect' === $this->payment_page) {
@@ -839,7 +841,9 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 
 				wc_add_notice('Invalid token ID', 'error');
 
-				return;
+				return array(
+					'result' => 'failure',
+				);
 			} else {
 
 				$status = $this->process_token_payment($token->get_token(), $order_id);
@@ -913,109 +917,105 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 	public function process_redirect_payment_option($order_id)
 	{
 
-		// Verify nonce before processing
+		// Verify nonce before processing (only for classic checkout; blocks checkout does not send this nonce)
 		if (
-			!isset($_POST['wc_hydrogen_payment_nonce']) ||
+			isset($_POST['wc_hydrogen_payment_nonce']) &&
 			!wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['wc_hydrogen_payment_nonce'])), 'wc_hydrogen_payment_nonce_action')
 		) {
 			wc_add_notice(__('Security check failed, please try again.', 'woocommerce'), 'error');
-			return;
+			return array(
+				'result' => 'failure',
+			);
 		}
 
-		$order = wc_get_order($order_id);
-		$amount = $order->get_total(); // Hydrogen payment amount
+		$order  = wc_get_order($order_id);
+		$amount = $order->get_total();
 		$txnref = $order_id . '_' . time();
 
 		$nonce = wp_create_nonce('wc_hydrogen_payment_nonce');
 
 		if ($this->testmode) {
-
-			$secret_key = $this->test_secret_key;
-
+			$secret_key   = $this->test_secret_key;
 			$hydrogen_url = 'https://api.hydrogenpay.com/bepay/api/v1/merchant/initiate-payment';
-
-			// Your code for test mode
 		} else {
-
-			$secret_key = $this->live_secret_key;
-
+			$secret_key   = $this->live_secret_key;
 			$hydrogen_url = 'https://api.hydrogenpay.com/bepay/api/v1/merchant/initiate-payment';
-
-			// Your code for live mode
 		}
 
-		// $callback_url = $order->get_checkout_payment_url(true);
 		$callback_url = add_query_arg('nonce', $nonce, $order->get_checkout_payment_url(true));
 
 		$payment_channels = $this->get_gateway_payment_channels($order);
 
-		$hydrogen_params1 = array(
-			'amount' => $amount,
-			'email' => $order->get_billing_email(),
-			'currency' => $order->get_currency(),
-			'description' => 'Payment for items ordered with ID  ' . $order->get_id(),
+		// Build the payload sent to the API (was previously $hydrogen_params1 missing extra fields)
+		$hydrogen_payload = array(
+			'amount'       => $amount,
+			'email'        => $order->get_billing_email(),
+			'currency'     => $order->get_currency(),
+			'description'  => 'Payment for items ordered with ID ' . $order->get_id(),
 			'customerName' => $order->get_billing_first_name() . ' ' . $order->get_billing_last_name(),
-			'meta' => $order->get_billing_first_name() . ' ' . $order->get_billing_last_name(),
-			'callback' => $callback_url,
-			'returnRef' => 2
+			'meta'         => $order->get_billing_first_name() . ' ' . $order->get_billing_last_name(),
+			'callback'     => $callback_url,
+			'returnRef'    => 2,
 		);
 
 		if (!empty($payment_channels)) {
-			$hydrogen_params['channels'] = $payment_channels;
+			$hydrogen_payload['channels'] = $payment_channels;
 		}
 
 		if ($this->split_payment) {
-			$hydrogen_params['subaccount'] = $this->subaccount_code;
-			$hydrogen_params['bearer'] = $this->charges_account;
+			$hydrogen_payload['subaccount'] = $this->subaccount_code;
+			$hydrogen_payload['bearer']     = $this->charges_account;
 
 			if (empty($this->transaction_charges)) {
-				$hydrogen_params['transaction_charge'] = '';
+				$hydrogen_payload['transaction_charge'] = '';
 			} else {
-				$hydrogen_params['transaction_charge'] = $this->transaction_charges * 100;
+				$hydrogen_payload['transaction_charge'] = $this->transaction_charges * 100;
 			}
 		}
 
-		$hydrogen_params['metadata']['custom_fields'] = $this->get_custom_fields($order_id);
-		$hydrogen_params['metadata']['cancel_action'] = wc_get_cart_url();
+		$custom_fields = $this->get_custom_fields($order_id);
+		if (!empty($custom_fields)) {
+			$hydrogen_payload['metadata']['custom_fields'] = $custom_fields;
+		}
+		$hydrogen_payload['metadata']['cancel_action'] = wc_get_cart_url();
 
 		$order->update_meta_data('_hydrogen_txn_ref', $txnref);
 		$order->save();
 
 		$headers = array(
 			'Authorization' => $secret_key,
-			'Content-Type' => 'application/json',
+			'Content-Type'  => 'application/json',
 			'Cache-Control' => 'no-cache',
 		);
 
 		$args = array(
 			'headers' => $headers,
 			'timeout' => 60,
-			'body' => wp_json_encode($hydrogen_params1),
+			'body'    => wp_json_encode($hydrogen_payload),
 		);
 
 		$request = wp_remote_post($hydrogen_url, $args);
 
 		if (is_wp_error($request)) {
-			wc_add_notice(__('Unable to redirect now to Hydrogen payment, try again, or use a popup', 'woo-hydrogen'), 'error');
-			return;
+			wc_add_notice(__('Unable to redirect to Hydrogen payment, please try again or use popup.', 'woo-hydrogen'), 'error');
+			return array(
+				'result' => 'failure',
+			);
 		}
 
 		$response_code = wp_remote_retrieve_response_code($request);
 		$response_body = json_decode(wp_remote_retrieve_body($request));
 
-		if (200 === $response_code) {
+		if (200 === $response_code && !empty($response_body->data->url)) {
 			return array(
-				'result' => 'success',
+				'result'   => 'success',
 				'redirect' => $response_body->data->url,
 			);
 		} else {
-			wc_add_notice(__('Unable to process payment, please try again', 'woo-hydrogen'), 'error');
-
-			// return array(
-			//     'result' => 'success',
-			//     'redirect' => $response_body,
-			// );
-			return;
+			wc_add_notice(__('Unable to process payment, please try again.', 'woo-hydrogen'), 'error');
+			return array(
+				'result' => 'failure',
+			);
 		}
 	}
 
@@ -1256,9 +1256,9 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 
 								wc_add_notice($notice, $notice_type);
 
-								// Redirect to cart after successful payment
+								// Redirect to order thank you page after successful payment
 
-								wp_redirect(wc_get_page_permalink('cart'));
+								wp_redirect($this->get_return_url($order));
 
 								exit;
 							}
@@ -1276,7 +1276,7 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 
 						// wp_send_json(array('result' => 'error', 'message' => 'Save successfully and also empty cart ' . $response_body));
 
-						wp_redirect(wc_get_page_permalink('cart'));
+						wp_redirect($this->get_return_url($order));
 
 						// wp_send_json($order->get_total());
 
@@ -1303,7 +1303,7 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 				wp_send_json(array('statusCode' => '90000', 'message' => 'Success message' . $response_body));
 
 				// wp_send_json(array('result' => 'error', 'message' => 'Redirect to cat page 2 ' . $response_body));
-				wp_redirect(wc_get_page_permalink('cart'));
+				wp_redirect($this->get_return_url($order));
 
 				exit;
 			}
@@ -1312,7 +1312,7 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 			// Handle the case where 'transactionRef' is not provided in the POST data
 			wp_send_json(array('result' => 'error', 'message' => 'TransactionRef not found in POST data.'));
 
-			wp_redirect(wc_get_page_permalink('cart'));
+			wp_redirect(wc_get_cart_url());
 
 			exit;
 		}
@@ -1509,9 +1509,9 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 
 								// wc_add_notice($notice, $notice_type);  // to-doLater
 
-								// Redirect to cart after successful payment
+								// Redirect to order thank you page after successful payment
 
-								wp_redirect(wc_get_page_permalink('cart'));
+								wp_redirect($this->get_return_url($order));
 
 								exit;
 							}
@@ -1529,7 +1529,7 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 
 						// wp_send_json(array('result' => 'error', 'message' => 'Save successfully and also empty cart ' . $response_body));
 
-						wp_redirect(wc_get_page_permalink('cart'));
+						wp_redirect($this->get_return_url($order));
 
 						// wp_send_json($order->get_total());
 
@@ -1556,7 +1556,7 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 				wp_send_json(array('statusCode' => '90000', 'message' => 'Success message' . $response_body));
 
 				// wp_send_json(array('result' => 'error', 'message' => 'Redirect to cat page 2 ' . $response_body));
-				wp_redirect(wc_get_page_permalink('cart'));
+				wp_redirect($this->get_return_url($order));
 
 				exit;
 			}
@@ -1565,7 +1565,7 @@ class WC_Gateway_Hydrogen extends WC_Payment_Gateway_CC
 			// Handle the case where 'transactionRef' is not provided in the POST data
 			wp_send_json(array('result' => 'error', 'message' => 'TransactionRef not found in POST data.'));
 
-			wp_redirect(wc_get_page_permalink('cart'));
+			wp_redirect(wc_get_cart_url());
 
 			exit;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,9 @@ Contributors: Hydrogenpay
 Donate link: https://hydrogenpay.com
 Tags: hydrogen, hydrogenpay, woocommerce, payment gateway, payments
 Requires at least: 3.0.0
-Tested up to: 8.2.5
-Stable tag: 1.0.0
+Tested up to: 10.9.4
+Requires PHP: 7.4
+Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,7 +52,8 @@ Hydrogen Payment Gateway enables fast, secure payments through card transactions
 
 3.	Latest releases
 
-    1. 1.0.0 - September 26, 2024.
+    1. 1.1.0 - July 2026.
+    2. 1.0.0 - September 26, 2024.
 
 
 4.	API references
@@ -96,3 +98,19 @@ we welcome your contributions to enhance the code.
 
 3. Hydrogen Popup/inline payment page
 
+
+== Changelog ==
+
+= 1.1.0 - July 2026 =
+* Fix: Fatal error `array_merge(): Argument #2 must be of type array, null given` when using WooCommerce Blocks / Store API checkout
+* Fix: Nonce verification now correctly allows WooCommerce Blocks checkout (which does not POST a nonce) to proceed
+* Fix: Payment payload bug in redirect mode — channels, split payment config, and metadata were built into an unused variable and never sent to the Hydrogen API
+* Fix: Successful payment now redirects to the WooCommerce Order Thank You page instead of the cart page
+* Fix: Cancelled/closed payment modal now redirects back to the checkout pay page so customers can retry
+* Add: Declared compatibility with WooCommerce Checkout Blocks (`cart_checkout_blocks`)
+* Add: Declared compatibility with WooCommerce HPOS (`custom_order_tables`)
+* Update: WC tested up to 10.9.4
+* Update: WordPress tested up to 7.0.1
+
+= 1.0.0 - September 26, 2024 =
+* Initial release

--- a/readme.txt
+++ b/readme.txt
@@ -104,9 +104,6 @@ we welcome your contributions to enhance the code.
 = 1.1.0 - July 2026 =
 * Fix: Fatal error `array_merge(): Argument #2 must be of type array, null given` when using WooCommerce Blocks / Store API checkout
 * Fix: Nonce verification now correctly allows WooCommerce Blocks checkout (which does not POST a nonce) to proceed
-* Fix: Payment payload bug in redirect mode — channels, split payment config, and metadata were built into an unused variable and never sent to the Hydrogen API
-* Fix: Successful payment now redirects to the WooCommerce Order Thank You page instead of the cart page
-* Fix: Cancelled/closed payment modal now redirects back to the checkout pay page so customers can retry
 * Add: Declared compatibility with WooCommerce Checkout Blocks (`cart_checkout_blocks`)
 * Add: Declared compatibility with WooCommerce HPOS (`custom_order_tables`)
 * Update: WC tested up to 10.9.4

--- a/woo-hydrogen.php
+++ b/woo-hydrogen.php
@@ -4,12 +4,12 @@
  * Plugin Name: Hydrogen Payment Gateway for WooCommerce
  * Plugin URI: https://hydrogenpay.com
  * Description: Hydrogen Payment Gateway for WooCommerce helps you process payments using cards and account transfers for faster delivery of goods and services.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Hydrogen
  * License: GPL-2.0+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
- * WC requires at least: 3.0.0
- * WC tested up to: 8.2.5
+ * WC requires at least: 5.0.0
+ * WC tested up to: 10.9.4
  * Text Domain: hydrogen-payment-gateway-for-woocommerce
  * Domain Path: /languages
  */
@@ -24,7 +24,7 @@ if (!defined('ABSPATH')) {
 define('WC_HYDROGEN_MAIN_FILE', __FILE__);
 define('WC_HYDROGEN_URL', untrailingslashit(plugins_url('/', __FILE__)));
 
-define('WC_HYDROGEN_VERSION', '1.0.0');
+define('WC_HYDROGEN_VERSION', '1.1.0');
 
 /**
  * Initialize Hydrogen payment gateway for wooCommerce.
@@ -136,7 +136,7 @@ function tbz_wc_add_hydrogen_gateway($methods)
 
 function tbz_wc_hydrogen_wc_missing_notice()
 {
-	
+
 	echo '<div class="error"><p><strong>' . wp_kses(
 		sprintf(
 			// Translators: %s is a link to install WooCommerce
@@ -203,6 +203,7 @@ add_action(
 	function () {
 		if (class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
 			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__, true);
 		}
 	}
 );


### PR DESCRIPTION
- Fix: Resolved fatal `array_merge(): Argument #2 must be of type array, null given` error during Latest WooCommerce Blocks / Store API checkout.
- Fix: Updated nonce verification to support WooCommerce Blocks checkout, which does not send a POST nonce.
- Add: Declared compatibility with WooCommerce Checkout Blocks (`cart_checkout_blocks`).
- Add: Declared compatibility with WooCommerce HPOS (`custom_order_tables`).
- Update: Tested with WooCommerce 10.9.4.
- Update: Tested with WordPress 7.0.1.